### PR TITLE
Add mecanum twist command and flexible speed handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 build/
+bin/


### PR DESCRIPTION
## Summary
- expand MOTOR_SPEEDS to support 4-wheel mecanum speeds and encoder-less control
- add MECANUM_TWIST command parsing and wheel-speed conversion
- ignore local `bin` directory used for tooling

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno ROSArduinoBridge` *(fails: Platform 'arduino:avr' not found)*

------
https://chatgpt.com/codex/tasks/task_b_68af169ed6ac8320b31b99e6c8d6c3a4